### PR TITLE
kpi: add mfnf-importer, update aggregator + grafana

### DIFF
--- a/kpi.tf
+++ b/kpi.tf
@@ -1,8 +1,9 @@
 locals {
   kpi = {
-    grafana_image_tag        = "1.5.0"
+    grafana_image_tag        = "1.6.2"
     mysql_importer_image_tag = "1.4.1"
-    aggregator_image_tag     = "1.6.4"
+    aggregator_image_tag     = "1.7.1"
+    mfnf_importer_image_tag  = "1.0.1"
   }
 }
 


### PR DESCRIPTION
Adds the K8-cronjob `mfnf-importer` which runs every day and inserts edits from MFNF into the kpi database.

The updates to `aggregator` and `grafana` make them visible in the UI.

Tested on dev.