### PR TITLE
Deploy version 0.52.1 of the server (api)

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -2,7 +2,7 @@ locals {
   api = {
     image_tags = {
       database_layer   = "0.3.66"
-      server           = "0.52.0"
+      server           = "0.52.1"
       cache_worker     = "0.4.2"
       api_db_migration = "0.1.0"
     }


### PR DESCRIPTION
The tag update was already applied via `terraform apply` ✨

<details>
<summary>What was deployed?</summary>
<ul>
<li><a href="https://github.com/serlo/api.serlo.org/releases/tag/v0.52.1">Tag v0.52.1 of api.serlo.org.</a></li>
<li>See the commits / diff <a href="https://github.com/serlo/api.serlo.org/compare/v0.52.0...9284379">here.</a></li>
</ul>
</details>