### PR TITLE
Add location_policy to node_pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "cluster" {
-  source   = "github.com/serlo/infrastructure-modules-gcloud.git//cluster?ref=v5.0.1"
+  source   = "github.com/serlo/infrastructure-modules-gcloud.git//cluster?ref=v5.3.0"
   name     = "${local.project}-cluster"
   project  = local.project
   location = local.zone
@@ -31,6 +31,7 @@ module "cluster" {
       initial_node_count = 2
       min_node_count     = 2
       max_node_count     = 10
+      location_policy    = "ANY"
     }
     non-preemptible = {
       machine_type       = local.cluster_machine_type
@@ -38,6 +39,7 @@ module "cluster" {
       initial_node_count = 0
       min_node_count     = 0
       max_node_count     = 10
+      location_policy    = "BALANCED"
     }
   }
 }


### PR DESCRIPTION
To sync the configuration in Google Cloud with what is present in the terraform declaration and state. 
More about location policy here: https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler.

Tested it by: 
* Running `terraform plan` - the output is:
```
...
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

✅ The result of running `terraform apply` is:
```
...
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

ℹ️  The `location_policy` argument was added in https://github.com/serlo/infrastructure-modules-gcloud/pull/9, and the change is included in the tag [v5.3.0](https://github.com/serlo/infrastructure-modules-gcloud/releases/tag/v5.3.0) of [infrastructure-modules-gcloud](https://github.com/serlo/infrastructure-modules-gcloud) ✨ 

---
Related to issue: https://github.com/serlo/infrastructure-env-production/issues/37
