### PR TITLE
Update the version of the infrastructure-modules-api module to use

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -19,7 +19,7 @@ module "api_redis" {
 }
 
 module "api" {
-  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v10.4.0"
+  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v10.5.0"
 
   namespace         = kubernetes_namespace.api_namespace.metadata.0.name
   image_tag         = local.api.image_tags.server


### PR DESCRIPTION
This version includes the update to the server (api) liveness probe to the /health endpoint that was added in https://github.com/serlo/api.serlo.org/pull/974 because Apollo Server 4 no longer supports built-in health checks, this means that the endpoint /.well-known/apollo/server-health is no longer supported.

Reference: https://www.apollographql.com/docs/apollo-server/migration/#health-checks.