### PR TITLE
Use new module versions that have the change to the kubernetes_cron_job_v1 resource

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -19,7 +19,7 @@ module "api_redis" {
 }
 
 module "api" {
-  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v10.5.0"
+  source = "github.com/serlo/infrastructure-modules-api.git//?ref=v10.5.1"
 
   namespace         = kubernetes_namespace.api_namespace.metadata.0.name
   image_tag         = local.api.image_tags.server

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ module "gcloud_postgres" {
 }
 
 module "athene2_dbsetup" {
-  source    = "github.com/serlo/infrastructure-modules-serlo.org.git//athene2_dbsetup?ref=v7.1.0"
+  source    = "github.com/serlo/infrastructure-modules-serlo.org.git//athene2_dbsetup?ref=v7.1.1"
   image     = "eu.gcr.io/serlo-shared/athene2-dbsetup-cronjob:3.0.3"
   namespace = kubernetes_namespace.serlo_org_namespace.metadata.0.name
   node_pool = module.cluster.node_pools.preemptible

--- a/serlo-org.tf
+++ b/serlo-org.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "serlo_org" {
-  source = "github.com/serlo/infrastructure-modules-serlo.org.git//?ref=v6.0.0"
+  source = "github.com/serlo/infrastructure-modules-serlo.org.git//?ref=v7.1.1"
 
   namespace         = kubernetes_namespace.serlo_org_namespace.metadata.0.name
   image_pull_policy = "IfNotPresent"


### PR DESCRIPTION
Instead of kubernetes_cron_job, since kubernetes_cron_job_v1 corresponds to `apiVersion: batch/v1`.